### PR TITLE
タイムゾーンを東京に変更

### DIFF
--- a/nova/config/application.rb
+++ b/nova/config/application.rb
@@ -20,6 +20,10 @@ Bundler.require(*Rails.groups)
 
 module Nova
   class Application < Rails::Application
+    # Set time_zone to Tokyo
+    config.time_zone = 'Tokyo'
+    config.active_record.default_timezone = :local
+
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.1
 

--- a/nova/config/application.rb
+++ b/nova/config/application.rb
@@ -22,7 +22,7 @@ module Nova
   class Application < Rails::Application
     # Set time_zone to Tokyo
     config.time_zone = 'Tokyo'
-    config.active_record.default_timezone = :local
+    config.active_record.default_timezone = :utc
 
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.1


### PR DESCRIPTION
タイムゾーンを東京に変更しました。
本番のDBのタイムゾーンがUTCなので`active_record.default_timezone`を`:utc`にしました。