### PR TITLE
pry でデバッグできるように

### DIFF
--- a/nova/Gemfile
+++ b/nova/Gemfile
@@ -36,8 +36,8 @@ group :development, :test do
   gem 'rspec-rails'
 
   # pry
-  gem 'pry-byebug'
   gem 'pry-rails'
+  gem 'pry-byebug'
 end
 
 group :development do

--- a/nova/Gemfile
+++ b/nova/Gemfile
@@ -34,6 +34,10 @@ group :development, :test do
 
   gem 'factory_bot_rails'
   gem 'rspec-rails'
+
+  # pry
+  gem 'pry-byebug'
+  gem 'pry-rails'
 end
 
 group :development do

--- a/nova/Gemfile.lock
+++ b/nova/Gemfile.lock
@@ -78,6 +78,7 @@ GEM
       xpath (~> 3.0)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
+    coderay (1.1.2)
     concurrent-ruby (1.0.5)
     crass (1.0.4)
     dante (0.2.0)
@@ -140,6 +141,14 @@ GEM
     parser (2.5.1.0)
       ast (~> 2.4.0)
     powerpack (0.1.1)
+    pry (0.11.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    pry-byebug (3.6.0)
+      byebug (~> 10.0)
+      pry (~> 0.10)
+    pry-rails (0.3.6)
+      pry (>= 0.10.4)
     public_suffix (3.0.2)
     puma (3.11.4)
     rack (2.0.5)
@@ -296,6 +305,8 @@ DEPENDENCIES
   locale_kit
   meta-tags
   mysql2 (>= 0.3.18, < 0.6.0)
+  pry-byebug
+  pry-rails
   puma (~> 3.7)
   rails (~> 5.2.0)
   rails-controller-testing

--- a/nova/config/puma.rb
+++ b/nova/config/puma.rb
@@ -3,7 +3,11 @@
 APP_ROOT = File.expand_path(File.join(__dir__, '..'))
 directory APP_ROOT
 pidfile File.join(APP_ROOT, 'tmp', 'pids', 'puma.pid')
-stdout_redirect File.join(APP_ROOT, 'log', 'stdout.log'), File.join(APP_ROOT, 'log', 'stderr.log'), true unless ENV.fetch('RAILS_ENV') == 'development'
+
+# Fetch RAILS_ENV or Set it `development`
+rails_env = ENV.fetch('RAILS_ENV') { 'development' }
+
+stdout_redirect File.join(APP_ROOT, 'log', 'stdout.log'), File.join(APP_ROOT, 'log', 'stderr.log'), true unless rails_env == 'development'
 
 # Puma can serve each request in a thread from an internal thread pool.
 # The `threads` method setting takes two numbers: a minimum and maximum.
@@ -11,7 +15,7 @@ stdout_redirect File.join(APP_ROOT, 'log', 'stdout.log'), File.join(APP_ROOT, 'l
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum; this matches the default thread size of Active Record.
 #
-threads_count = if ENV.fetch('RAILS_ENV') == 'development'
+threads_count = if rails_env == 'development'
                   ENV.fetch('RAILS_MAX_THREADS') { 1 }
                 else
                   ENV.fetch('RAILS_MAX_THREADS') { 5 }
@@ -24,7 +28,7 @@ port        ENV.fetch('PORT') { 3000 }
 
 # Specifies the `environment` that Puma will run in.
 #
-environment ENV.fetch('RAILS_ENV') { 'development' }
+environment rails_env
 
 # Specifies the number of `workers` to boot in clustered mode.
 # Workers are forked webserver processes. If using threads and workers together

--- a/nova/config/puma.rb
+++ b/nova/config/puma.rb
@@ -3,7 +3,7 @@
 APP_ROOT = File.expand_path(File.join(__dir__, '..'))
 directory APP_ROOT
 pidfile File.join(APP_ROOT, 'tmp', 'pids', 'puma.pid')
-stdout_redirect File.join(APP_ROOT, 'log', 'stdout.log'), File.join(APP_ROOT, 'log', 'stderr.log'), true
+# stdout_redirect File.join(APP_ROOT, 'log', 'stdout.log'), File.join(APP_ROOT, 'log', 'stderr.log'), true
 
 # Puma can serve each request in a thread from an internal thread pool.
 # The `threads` method setting takes two numbers: a minimum and maximum.

--- a/nova/config/puma.rb
+++ b/nova/config/puma.rb
@@ -3,7 +3,7 @@
 APP_ROOT = File.expand_path(File.join(__dir__, '..'))
 directory APP_ROOT
 pidfile File.join(APP_ROOT, 'tmp', 'pids', 'puma.pid')
-# stdout_redirect File.join(APP_ROOT, 'log', 'stdout.log'), File.join(APP_ROOT, 'log', 'stderr.log'), true
+stdout_redirect File.join(APP_ROOT, 'log', 'stdout.log'), File.join(APP_ROOT, 'log', 'stderr.log'), true unless ENV.fetch('RAILS_ENV') == 'development'
 
 # Puma can serve each request in a thread from an internal thread pool.
 # The `threads` method setting takes two numbers: a minimum and maximum.
@@ -11,7 +11,11 @@ pidfile File.join(APP_ROOT, 'tmp', 'pids', 'puma.pid')
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum; this matches the default thread size of Active Record.
 #
-threads_count = ENV.fetch('RAILS_MAX_THREADS') { 5 }
+threads_count = if ENV.fetch('RAILS_ENV') == 'development'
+                  ENV.fetch('RAILS_MAX_THREADS') { 1 }
+                else
+                  ENV.fetch('RAILS_MAX_THREADS') { 5 }
+                end
 threads threads_count, threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.


### PR DESCRIPTION
`binding.pry`
を仕込むことでデバッグできるようにした

変更点
- pry の gem を入れた
- マルチスレッドで動いていたので、 development 環境でのみ thread_count を 1 にした
- 標準出力が全て log file に書き出される仕様になっていたので、 dev 環境でのみ標準出力として吐くようにした