### PR TITLE
ログイン時にパスワードを間違えた場合に、メッセージを表示する 

### DIFF
--- a/nova/app/controllers/application_controller.rb
+++ b/nova/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
+  add_flash_types :success, :info, :warning, :danger
   include Loginable
 
   protect_from_forgery with: :exception

--- a/nova/app/controllers/sessions_controller.rb
+++ b/nova/app/controllers/sessions_controller.rb
@@ -12,6 +12,7 @@ class SessionsController < ApplicationController
       self.current_user = @user
       redirect_to dashboard_path
     else
+      flash.now[:danger] = 'Invalid email/password combination'
       render :new, status: :bad_request
     end
   end

--- a/nova/app/views/layouts/application.html.slim
+++ b/nova/app/views/layouts/application.html.slim
@@ -37,6 +37,9 @@ html(lang="#{I18n.locale}" class="#{html_classes.join(' ')}")
         .container
           .columns
             .column.is-8.is-offset-2
+              - flash.each do |key, value|
+                div class=("alert alert-#{key}")
+                  = value
 
               = yield
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/38023221/39735715-c4704d52-52b7-11e8-95dc-04f35f251e3c.png)

失敗時に写真のようなflashを表示する。
今回のPRではadd_flash_types入れたけど使ってない