### PR TITLE
存在しないユーザーのメールアドレスにrequestを送信した時にエラーメッセージを表示する

### DIFF
--- a/nova/app/assets/javascripts/dashboard.js
+++ b/nova/app/assets/javascripts/dashboard.js
@@ -146,16 +146,17 @@ document.addEventListener('DOMContentLoaded', function() {
 
       addTarget: function(event) {
         if(event) { event.preventDefault(); }
+        var self = this;
         api.post('/api/user_emails', { email: this.target} ).
             then(function (json) {
               if(json.error == 'Not found'){
                 alert("そのメールアドレスは登録されていません")
               }else{
+                if(!self.newRemitRequest.emails.includes(self.target)){
+                  self.newRemitRequest.emails.push(self.target)
+                }
               }
         })
-        if(!this.newRemitRequest.emails.includes(this.target)) {
-          this.newRemitRequest.emails.push(this.target);
-        }
       },
       removeTarget: function(email, event) {
         if(event) { event.preventDefault(); }

--- a/nova/app/assets/javascripts/dashboard.js
+++ b/nova/app/assets/javascripts/dashboard.js
@@ -128,7 +128,13 @@ document.addEventListener('DOMContentLoaded', function() {
       },
       addTarget: function(event) {
         if(event) { event.preventDefault(); }
-
+        api.post('/api/user_emails', { email: this.target} ).
+            then(function (json) {
+              if(json.error == 'Not found'){
+                alert("そのメールアドレスは登録されていません")
+              }else{
+              }
+        })
         if(!this.newRemitRequest.emails.includes(this.target)) {
           this.newRemitRequest.emails.push(this.target);
         }

--- a/nova/app/assets/javascripts/dashboard.js
+++ b/nova/app/assets/javascripts/dashboard.js
@@ -113,7 +113,7 @@ document.addEventListener('DOMContentLoaded', function() {
     },
     methods: {
       show_modal: function(amount) {
-        this.charge_amount = amount
+        this.charge_amount = amount;
         this.isActiveChargeConfirmDialog = true;
       },
       charge: function(amount, event) {
@@ -150,10 +150,10 @@ document.addEventListener('DOMContentLoaded', function() {
         api.post('/api/user_emails', { email: this.target} ).
             then(function (json) {
               if(json.error == 'Not found'){
-                alert("そのメールアドレスは登録されていません")
+                alert("そのメールアドレスは登録されていません");
               }else{
                 if(!self.newRemitRequest.emails.includes(self.target)){
-                  self.newRemitRequest.emails.push(self.target)
+                  self.newRemitRequest.emails.push(self.target);
                 }
               }
         })

--- a/nova/app/controllers/api/user_emails_controller.rb
+++ b/nova/app/controllers/api/user_emails_controller.rb
@@ -3,7 +3,7 @@ class Api::UserEmailsController < Api::ApplicationController
     if user_email_exists?(params[:email])
       render json: {}
     else
-        render json: { error: 'Not found'}, status: :not_found
+      render json: { error: 'Not found'}, status: :not_found
     end
   end
 

--- a/nova/app/controllers/api/user_emails_controller.rb
+++ b/nova/app/controllers/api/user_emails_controller.rb
@@ -1,0 +1,15 @@
+class Api::UserEmailsController < Api::ApplicationController
+  def create
+    if user_email_exists?(params[:email])
+      render json: {}
+    else
+        render json: { error: 'Not found'}, status: :not_found
+    end
+  end
+
+  private
+
+  def user_email_exists?(email)
+    User.where(email: email).exists?
+  end
+end

--- a/nova/config/routes.rb
+++ b/nova/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   namespace :api, defaults: { format: 'json' } do
     resource :user, only: %i[show update]
     resource :credit_card, only: %i[show create]
+    resources :user_emails, only: %i[create]
     resources :charges, only: %i[index create]
     resources :remit_requests, only: %i[index create] do
       member do


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/38023221/39752636-0107940c-52f7-11e8-87a3-579d2f188cde.png)

request先に存在しないユーザーのメールアドレスを指定した場合、エラーメッセージを表示する。
`else`以下に`this.newRemitRequest.emails.push(this.target);`を実行したいが、
`Cannot read property 'emails' of undefined`となる。

現在アラート表示になっているが、modal中にメッセージを表示させるつもり

close https://github.com/tnandate/2018-newbies/issues/5