### PR TITLE
チャージ時に確認用のモダルを表示する

### DIFF
--- a/nova/app/assets/javascripts/dashboard.js
+++ b/nova/app/assets/javascripts/dashboard.js
@@ -63,6 +63,7 @@ document.addEventListener('DOMContentLoaded', function() {
       sentRemits: [],
       hasCreditCard: hasCreditCard,
       isActiveNewRemitForm: false,
+      isActiveNewRemitForm2: false,
       target: "",
       user: {
         email: "",

--- a/nova/app/assets/javascripts/dashboard.js
+++ b/nova/app/assets/javascripts/dashboard.js
@@ -58,6 +58,7 @@ document.addEventListener('DOMContentLoaded', function() {
     data: {
       currentTab: 'remits',
       amount: 0,
+      charge_amount: 0,
       charges: [],
       recvRemits: [],
       sentRemits: [],
@@ -102,6 +103,10 @@ document.addEventListener('DOMContentLoaded', function() {
       if(form){ creditCard.mount(form); }
     },
     methods: {
+      show_modal: function(amount) {
+        this.charge_amount = amount
+        this.isActiveChargeConfirmDialog = true;
+      },
       charge: function(amount, event) {
         if(event) { event.preventDefault(); }
 

--- a/nova/app/assets/javascripts/dashboard.js
+++ b/nova/app/assets/javascripts/dashboard.js
@@ -63,7 +63,7 @@ document.addEventListener('DOMContentLoaded', function() {
       sentRemits: [],
       hasCreditCard: hasCreditCard,
       isActiveNewRemitForm: false,
-      isActiveNewRemitForm2: false,
+      isActiveChargeConfirmDialog: false,
       target: "",
       user: {
         email: "",

--- a/nova/app/views/dashboard/show.html.slim
+++ b/nova/app/views/dashboard/show.html.slim
@@ -129,6 +129,6 @@
     .modal-card
       senction.modal-card-body
         .heading 本当にチャージしますか？
-        .button.button.is_primary(@click="charge(50,$event)" @click.prevent= "isActiveChargeConfirmDialog = false ") はい
+        .button.button.is_primary(@click="charge(charge_amount, $event)" @click.prevent= "isActiveChargeConfirmDialog = false ") はい
         .button.button.is_primary(@click.prevent = "isActiveChargeConfirmDialog = false")いいえ
     button.modal-close.is-large(@click.prevent= "isActiveChargeConfirmDialog= false")

--- a/nova/app/views/dashboard/show.html.slim
+++ b/nova/app/views/dashboard/show.html.slim
@@ -129,5 +129,6 @@
     .modal-card
       senction.modal-card-body
         .heading 本当にチャージしますか？
-        .button.button.is_primary(@click="charge(50,$event)") はい
+        .button.button.is_primary(@click="charge(50,$event)" @click.prevent= "isActiveNewRemitForm2 = false ") はい
+        .button.button.is_primary(@click.prevent = "isActiveNewRemitForm2 = false")いいえ
     button.modal-close.is-large(@click.prevent= "isActiveNewRemitForm2 = false")

--- a/nova/app/views/dashboard/show.html.slim
+++ b/nova/app/views/dashboard/show.html.slim
@@ -22,6 +22,7 @@
         a.button(:disabled="!hasCreditCard" @click="charge(500, $event)") 500円
         a.button(:disabled="!hasCreditCard" @click="charge(1000, $event)") 1,000円
         a.button(:disabled="!hasCreditCard" @click="charge(5000, $event)") 5,000円
+        a.button(@click="isActiveNewRemitForm2 = true") もだる
 
   .columns.
     .column.is-12
@@ -96,7 +97,7 @@
             button.button.is-primary(type="submit") Update
 
   .modal(:class='{ "is-active": isActiveNewRemitForm }')
-    .modal-background(@click.prevent="isActiveNewRemitForm = false")
+    .modal-background(@click.prevent= "isActiveNewRemitForm = false")
     .modal-card
       section.modal-card-body
         .heading New Remit Request
@@ -120,4 +121,13 @@
                 input.input(type='number' v-model="newRemitRequest.amount" placeholder="Amount")
               .control
                 button.button.is-primary(@click="sendRemitRequest($event)") Send
-    button.modal-close.is-large(@click.prevent="isActiveNewRemitForm = false")
+    button.modal-close.is-large(@click.prevent= "isActiveNewRemitForm = false")
+
+
+  .modal(:class='{ "is-active": isActiveNewRemitForm2 }')
+    .modal-background(@click.prevent= "isActiveNewRemitForm2 = false")
+    .modal-card
+      senction.modal-card-body
+        .heading 本当にチャージしますか？
+        .button.button.is_primary(@click="charge(50,$event)") はい
+    button.modal-close.is-large(@click.prevent= "isActiveNewRemitForm2 = false")

--- a/nova/app/views/dashboard/show.html.slim
+++ b/nova/app/views/dashboard/show.html.slim
@@ -18,11 +18,10 @@
     .column.is-8
       .heading Charge
       .buttons
-        a.button(:disabled="!hasCreditCard" @click="charge(100, $event)") 100円
-        a.button(:disabled="!hasCreditCard" @click="charge(500, $event)") 500円
-        a.button(:disabled="!hasCreditCard" @click="charge(1000, $event)") 1,000円
-        a.button(:disabled="!hasCreditCard" @click="charge(5000, $event)") 5,000円
-        a.button(@click="isActiveChargeConfirmDialog = true") もだる
+        a.button(:disabled="!hasCreditCard" @click="show_modal(100)" ) 100円
+        a.button(:disabled="!hasCreditCard" @click="show_modal(500)") 500円
+        a.button(:disabled="!hasCreditCard" @click="show_modal(1000)") 1,000円
+        a.button(:disabled="!hasCreditCard" @click="show_modal(5000)") 5,000円
 
   .columns.
     .column.is-12

--- a/nova/app/views/dashboard/show.html.slim
+++ b/nova/app/views/dashboard/show.html.slim
@@ -22,7 +22,7 @@
         a.button(:disabled="!hasCreditCard" @click="charge(500, $event)") 500円
         a.button(:disabled="!hasCreditCard" @click="charge(1000, $event)") 1,000円
         a.button(:disabled="!hasCreditCard" @click="charge(5000, $event)") 5,000円
-        a.button(@click="isActiveNewRemitForm2 = true") もだる
+        a.button(@click="isActiveChargeConfirmDialog = true") もだる
 
   .columns.
     .column.is-12
@@ -124,11 +124,11 @@
     button.modal-close.is-large(@click.prevent= "isActiveNewRemitForm = false")
 
 
-  .modal(:class='{ "is-active": isActiveNewRemitForm2 }')
-    .modal-background(@click.prevent= "isActiveNewRemitForm2 = false")
+  .modal(:class='{ "is-active": isActiveChargeConfirmDialog }')
+    .modal-background(@click.prevent= "isActiveChargeConfirmDialog = false")
     .modal-card
       senction.modal-card-body
         .heading 本当にチャージしますか？
-        .button.button.is_primary(@click="charge(50,$event)" @click.prevent= "isActiveNewRemitForm2 = false ") はい
-        .button.button.is_primary(@click.prevent = "isActiveNewRemitForm2 = false")いいえ
-    button.modal-close.is-large(@click.prevent= "isActiveNewRemitForm2 = false")
+        .button.button.is_primary(@click="charge(50,$event)" @click.prevent= "isActiveChargeConfirmDialog = false ") はい
+        .button.button.is_primary(@click.prevent = "isActiveChargeConfirmDialog = false")いいえ
+    button.modal-close.is-large(@click.prevent= "isActiveChargeConfirmDialog= false")


### PR DESCRIPTION
![screencast 2018-05-09 12-23-14](https://user-images.githubusercontent.com/38023221/39794153-e0dd879e-5383-11e8-9572-b93fcb72fc6c.gif)


チャージ時の確認用のモダルの追加（50円課金するものを試作）
現在４通り（100,500,1000,5000）あるのでそれぞれに適応させるにはどうしたらいいだろう？

close https://github.com/tnandate/2018-newbies/issues/29