### PR TITLE
エラーメッセージをもっと見やすくする

### DIFF
--- a/nova/app/views/shared/_error_messages.html.slim
+++ b/nova/app/views/shared/_error_messages.html.slim
@@ -1,7 +1,6 @@
 - if object.errors.any?
-  #error_explanation
-    .alert.alert-danger
-      | The form contains #{pluralize(object.errors.count, "error")}.
-    ul
-      - object.errors.full_messages.each do |msg|
-        li= msg
+  .notification.is-danger
+    | The form contains #{pluralize(object.errors.count, "error")}.
+  ul
+    - object.errors.full_messages.each do |msg|
+      li= msg


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/38023221/39799005-8bc171de-539d-11e8-9f43-5922ed75acb0.png)

エラー数を赤で囲って目立たせる。
bulmaのドキュメントより
https://bulma.io/documentation/

close https://github.com/tnandate/2018-newbies/issues/24