### PR TITLE
ユーザ情報更新時にメッセージを表示させる

### DIFF
--- a/nova/app/assets/javascripts/dashboard.js
+++ b/nova/app/assets/javascripts/dashboard.js
@@ -66,6 +66,7 @@ document.addEventListener('DOMContentLoaded', function() {
       isActiveNewRemitForm: false,
       isActiveChargeConfirmDialog: false,
       target: "",
+      setting_notice: "",
       creditCard: {
         brand: "",
         last4: "",

--- a/nova/app/assets/javascripts/dashboard.js
+++ b/nova/app/assets/javascripts/dashboard.js
@@ -213,6 +213,11 @@ document.addEventListener('DOMContentLoaded', function() {
         var self = this;
         api.put('/api/user?attribute=nickname', { user: this.user }).
           then(function(json) {
+            if(json.errors){
+                self.setting_notice = "更新に失敗しました"
+            }else{
+                self.setting_notice = "更新しました"
+            }
             self.user = json;
           });
       },
@@ -222,6 +227,11 @@ document.addEventListener('DOMContentLoaded', function() {
         var self = this;
         api.put('/api/user?attribute=email', { user: this.user }).
           then(function(json) {
+            if(json.errors){
+              self.setting_notice = "更新に失敗しました"
+            }else{
+              self.setting_notice = "更新しました"
+            }
             self.user = json;
           });
       },
@@ -231,6 +241,11 @@ document.addEventListener('DOMContentLoaded', function() {
         var self = this;
         api.put('/api/user?attribute=password', { user: this.user }).
           then(function(json) {
+            if(json.errors){
+                self.setting_notice = "更新に失敗しました"
+            }else{
+                self.setting_notice = "更新しました"
+            }
             self.user = json;
           });
       },

--- a/nova/app/assets/javascripts/dashboard.js
+++ b/nova/app/assets/javascripts/dashboard.js
@@ -66,7 +66,7 @@ document.addEventListener('DOMContentLoaded', function() {
       isActiveNewRemitForm: false,
       isActiveChargeConfirmDialog: false,
       target: "",
-      setting_notice: "",
+      register_notification: "",
       creditCard: {
         brand: "",
         last4: "",
@@ -214,9 +214,9 @@ document.addEventListener('DOMContentLoaded', function() {
         api.put('/api/user?attribute=nickname', { user: this.user }).
           then(function(json) {
             if(json.errors){
-                self.setting_notice = "更新に失敗しました"
+                self.register_notification = "更新に失敗しました"
             }else{
-                self.setting_notice = "更新しました"
+                self.register_notification = "更新しました"
             }
             self.user = json;
           });
@@ -228,9 +228,9 @@ document.addEventListener('DOMContentLoaded', function() {
         api.put('/api/user?attribute=email', { user: this.user }).
           then(function(json) {
             if(json.errors){
-              self.setting_notice = "更新に失敗しました"
+              self.register_notification = "更新に失敗しました"
             }else{
-              self.setting_notice = "更新しました"
+              self.register_notification = "更新しました"
             }
             self.user = json;
           });
@@ -242,9 +242,9 @@ document.addEventListener('DOMContentLoaded', function() {
         api.put('/api/user?attribute=password', { user: this.user }).
           then(function(json) {
             if(json.errors){
-                self.setting_notice = "更新に失敗しました"
+                self.register_notification = "更新に失敗しました"
             }else{
-                self.setting_notice = "更新しました"
+                self.register_notification = "更新しました"
             }
             self.user = json;
           });

--- a/nova/app/views/dashboard/show.html.slim
+++ b/nova/app/views/dashboard/show.html.slim
@@ -97,7 +97,7 @@
   .columns(v-if="currentTab === 'settings'")
     .column.is-12
       .heading Settings
-      .p= '{{setting_notice}}'
+      .p= '{{ register_notification}}'
       form(@submit="updateUserNickname($event)")
         .field
           label.label Nickname

--- a/nova/app/views/dashboard/show.html.slim
+++ b/nova/app/views/dashboard/show.html.slim
@@ -97,7 +97,7 @@
   .columns(v-if="currentTab === 'settings'")
     .column.is-12
       .heading Settings
-
+      .p= '{{setting_notice}}'
       form(@submit="updateUserNickname($event)")
         .field
           label.label Nickname


### PR DESCRIPTION
成功時
![image](https://user-images.githubusercontent.com/38023221/39860390-2934b70c-5478-11e8-8bf4-540a8af7b8cb.png)

失敗時（空入力）
![image](https://user-images.githubusercontent.com/38023221/39860418-4012f236-5478-11e8-95f1-9b9398d54378.png)

ユーザー情報更新時にメッセージを表示させる。