### PR TITLE
[WIP]ユーザー更新時にエラーが出た場合に詳細を表示する。

### DIFF
--- a/nova/app/assets/javascripts/dashboard.js
+++ b/nova/app/assets/javascripts/dashboard.js
@@ -118,6 +118,14 @@ document.addEventListener('DOMContentLoaded', function() {
       if(form){ creditCard.mount(form); }
     },
     methods: {
+      show_register_notification: function(json){
+        if(json.errors){
+          this.register_notification = "更新に失敗しました。"
+          this.register_error_messages += json.errors
+        }else{
+          this.register_notification = "更新しました。"
+        }
+      },
       show_charge_modal: function(amount) {
         if(hasCreditCard) {
           this.charge_amount = amount;
@@ -225,12 +233,7 @@ document.addEventListener('DOMContentLoaded', function() {
         var self = this;
         api.put('/api/user?attribute=nickname', { user: this.user }).
           then(function(json) {
-            if(json.errors){
-                self.register_notification = "更新に失敗しました"
-                self.register_error_messages += json.errors
-            }else{
-                self.register_notification = "更新しました"
-            }
+            self.show_register_notification(json);
             self.user = json;
           });
       },
@@ -240,12 +243,7 @@ document.addEventListener('DOMContentLoaded', function() {
         var self = this;
         api.put('/api/user?attribute=email', { user: this.user }).
           then(function(json) {
-            if(json.errors){
-                self.register_notification = "更新に失敗しました"
-                self.register_error_messages += json.errors
-            }else{
-                self.register_notification = "更新しました"
-            }
+            self.show_register_notification(json);
             self.user = json;
           });
       },
@@ -255,12 +253,7 @@ document.addEventListener('DOMContentLoaded', function() {
         var self = this;
         api.put('/api/user?attribute=password', { user: this.user }).
           then(function(json) {
-            if(json.errors){
-                self.register_notification = "更新に失敗しました"
-                self.register_error_messages += json.errors
-            }else{
-                self.register_notification = "更新しました"
-            }
+            self.show_register_notification(json);
             self.user = json;
           });
       },

--- a/nova/app/assets/javascripts/dashboard.js
+++ b/nova/app/assets/javascripts/dashboard.js
@@ -69,6 +69,7 @@ document.addEventListener('DOMContentLoaded', function() {
       isActiveDeleteCreditCard: false,
       target: "",
       register_notification: "",
+      register_error_messages: "",
       creditCard: {
         brand: "",
         last4: "",
@@ -226,6 +227,7 @@ document.addEventListener('DOMContentLoaded', function() {
           then(function(json) {
             if(json.errors){
                 self.register_notification = "更新に失敗しました"
+                self.register_error_messages += json.errors
             }else{
                 self.register_notification = "更新しました"
             }
@@ -239,9 +241,10 @@ document.addEventListener('DOMContentLoaded', function() {
         api.put('/api/user?attribute=email', { user: this.user }).
           then(function(json) {
             if(json.errors){
-              self.register_notification = "更新に失敗しました"
+                self.register_notification = "更新に失敗しました"
+                self.register_error_messages += json.errors
             }else{
-              self.register_notification = "更新しました"
+                self.register_notification = "更新しました"
             }
             self.user = json;
           });
@@ -254,6 +257,7 @@ document.addEventListener('DOMContentLoaded', function() {
           then(function(json) {
             if(json.errors){
                 self.register_notification = "更新に失敗しました"
+                self.register_error_messages += json.errors
             }else{
                 self.register_notification = "更新しました"
             }

--- a/nova/app/assets/javascripts/dashboard.js
+++ b/nova/app/assets/javascripts/dashboard.js
@@ -121,7 +121,9 @@ document.addEventListener('DOMContentLoaded', function() {
       show_register_notification: function(json){
         if(json.errors){
           this.register_notification = "更新に失敗しました。"
-          this.register_error_messages += json.errors
+          for(var error of json.errors){
+            this.register_error_messages += error;
+          }
         }else{
           this.register_notification = "更新しました。"
         }

--- a/nova/app/views/dashboard/show.html.slim
+++ b/nova/app/views/dashboard/show.html.slim
@@ -117,7 +117,7 @@
   .columns(v-if="currentTab === 'settings'")
     .column.is-12
       .heading Settings
-      .p= '{{ register_notification}}'
+      .p= '{{ register_notification }}'
       ul
         li= '{{ register_error_messages }}'
       form(@submit="updateUserNickname($event)")

--- a/nova/app/views/dashboard/show.html.slim
+++ b/nova/app/views/dashboard/show.html.slim
@@ -118,6 +118,8 @@
     .column.is-12
       .heading Settings
       .p= '{{ register_notification}}'
+      ul
+        li= '{{ register_error_messages }}'
       form(@submit="updateUserNickname($event)")
         .field
           label.label Nickname


### PR DESCRIPTION
nicknameが空の場合
![image](https://user-images.githubusercontent.com/38023221/39984024-b5d09e6e-5794-11e8-81c4-db2a5d30def5.png)

コード汚い。要リファクタ
clonse https://github.com/tnandate/2018-newbies/issues/82