### PR TITLE
ES6 syntax

### DIFF
--- a/nova/app/assets/javascripts/dashboard.js
+++ b/nova/app/assets/javascripts/dashboard.js
@@ -121,9 +121,7 @@ document.addEventListener('DOMContentLoaded', function() {
       show_register_notification: function(json){
         if(json.errors){
           this.register_notification = "更新に失敗しました。"
-          for(var error of json.errors){
-            this.register_error_messages += error;
-          }
+            this.register_error_messages += json.errors;
         }else{
           this.register_notification = "更新しました。"
         }


### PR DESCRIPTION
```
[2018-05-15 02:29:43.289] [d-4QOBU7DDS][stderr]Uglifier::Error: Unexpected token name «of», expected punc «;». To use ES6 syntax, harmony mode must be enabled with Uglifier.new(:harmony => true).
```

ES6文法で書いていたため