### PR TITLE
ES6 文法の許可

### DIFF
--- a/nova/config/environments/production.rb
+++ b/nova/config/environments/production.rb
@@ -26,7 +26,10 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  # config.assets.js_compressor = :uglifier
+  #
+  # ES6 の文法を許可するために harmony option を true としている
+  config.assets.js_compressor = Uglifier.new(harmony: :true)
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
デプロイ時に assets precompile に失敗していた

ログを見ると
`/opt/codedeploy-agent/deployment-root/deployment-logs`

```
[2018-05-15 02:29:43.289] [d-4QOBU7DDS][stderr]Uglifier::Error: Unexpected token name «of», expected punc «;». To use ES6 syntax, harmony mode must be enabled with Uglifier.new(:harmony => true).
```

 となっていたため、 harmony: :true としてみた